### PR TITLE
bump Arrow + Legolas compat

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        legolas-version:
+          - '0.2'
+          - '0.3'
         version:
           - '1.5' # earliest supported version
           - '1' # current release
@@ -38,6 +41,11 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - name: "Install Legolas version"
+        shell: julia --color=yes --project=. {0}
+        run: |
+          using Pkg
+          Pkg.add(Pkg.PackageSpec(; name="Legolas", version="${{ matrix.legolas-version }}"))
       - uses: actions/cache@v2
         with:
           path: ~/.julia/artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ on:
       - 'Project.toml'
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - Legolas ${{ matrix.legolas-version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LegolasFlux"
 uuid = "eb5f792d-d1b1-4535-bae3-d5649ec7daa4"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,10 @@ Legolas = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-Arrow = "1"
+Arrow = "1, 2"
 Flux = "0.12"
 Functors = "0.2.6"
-Legolas = "0.1, 0.2"
+Legolas = "0.1, 0.2, 0.3"
 Tables = "1"
 julia = "1.5"
 


### PR DESCRIPTION
Need to do these together to actually get the new versions in CI. Replaces #6 and #8.

This should be fine since the breakage only affected things if you were using deprecated behavior or explicitly handling the metadata (instead of letting Legolas do it for you). But let's see what CI says.