### PR TITLE
allow missing weights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Manifest.toml
+test/my_model.model.arrow

--- a/src/LegolasFlux.jl
+++ b/src/LegolasFlux.jl
@@ -83,7 +83,7 @@ ArrowTypes.JuliaType(::Val{WEIGHTS_ARROW_NAME}) = Weights
 #####
 
 const ModelRow = Legolas.@row("legolas-flux.model@1",
-                              weights::Weights = Weights(weights),
+                              weights::Union{Missing,Weights} = ismissing(weights) ? missing : Weights(weights),
                               architecture_version::Union{Missing,Int})
 #####
 ##### Utilities

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,18 +18,20 @@ end
 # This simple model should work with both Flux's `params/loadparams!` and
 # our `weights/load_weights!`. The only difference is in layers with `!isempty(other_weights(layer))`.
 @testset "using ($get_weights, $load_weights)" for (get_weights, load_weights) in [(fetch_weights, load_weights!, params, Flux.loadparams!)]
-    my_model = make_my_model()
-    load_weights(my_model, test_weights())
-
-    model_row = ModelRow(; weights=collect(get_weights(my_model)))
-    write_model_row("my_model.model.arrow", model_row)
 
     # quick test with `missing` weights.
     model_row = ModelRow(; weights=missing)
     write_model_row("my_model.model.arrow", model_row)
     rt = read_model_row("my_model.model.arrow")
     @test isequal(model_row, rt)
-        
+
+    my_model = make_my_model()
+    load_weights(my_model, test_weights())
+
+    model_row = ModelRow(; weights=collect(get_weights(my_model)))
+    write_model_row("my_model.model.arrow", model_row)
+
+
     fresh_model = make_my_model()
 
     model_row = read_model_row("my_model.model.arrow")
@@ -80,7 +82,7 @@ end
     @test Weights(FlatArray{Float64}.(v)) isa Weights{Float64}
 
     w = Weights(v)
-    tbl = [(; weights = w)]
+    tbl = [(; weights=w)]
     @test Arrow.Table(Arrow.tobuffer(tbl)).weights[1] == w
 end
 
@@ -89,7 +91,7 @@ end
         mk_model = () -> (Random.seed!(1); Chain(Dense(1, 10), Dense(10, 10), layer(1), Dense(10, 1)))
         model = mk_model()
         trainmode!(model)
-        x = reshape([1f0], 1, 1, 1)
+        x = reshape([1.0f0], 1, 1, 1)
         for i in 1:10
             x = model(x)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,12 @@ end
     model_row = ModelRow(; weights=collect(get_weights(my_model)))
     write_model_row("my_model.model.arrow", model_row)
 
+    # quick test with `missing` weights.
+    model_row = ModelRow(; weights=missing)
+    write_model_row("my_model.model.arrow", model_row)
+    rt = read_model_row("my_model.model.arrow")
+    @test isequal(model_row, rt)
+        
     fresh_model = make_my_model()
 
     model_row = read_model_row("my_model.model.arrow")


### PR DESCRIPTION
alternative to #14

Instead of creating a `Weights{Missing}` object, we just pass along the `missing`