### PR TITLE
Allow Functors v0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LegolasFlux"
 uuid = "eb5f792d-d1b1-4535-bae3-d5649ec7daa4"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 Arrow = "1, 2"
 Flux = "0.12, 0.13"
-Functors = "0.2.6"
+Functors = "0.2.6, 0.3"
 Legolas = "0.1, 0.2, 0.3"
 Tables = "1"
 julia = "1.5"


### PR DESCRIPTION
The breaking changes are from https://github.com/FluxML/Functors.jl/pull/33 and nothing there looks like it should affect us here. But we can see what CI says.