### PR TITLE
Fix Arrow deserialization for `FlatArray`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LegolasFlux"
 uuid = "eb5f792d-d1b1-4535-bae3-d5649ec7daa4"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/LegolasFlux.jl
+++ b/src/LegolasFlux.jl
@@ -33,6 +33,7 @@ Base.hash(f::FlatArray, h::UInt) = hash(:FlatArray, hash(f.vec, hash(f.size, h))
 const FLATARRAY_ARROW_NAME = Symbol("JuliaLang.LegolasFlux.FlatArray")
 ArrowTypes.arrowname(::Type{<:FlatArray}) = FLATARRAY_ARROW_NAME
 ArrowTypes.JuliaType(::Val{FLATARRAY_ARROW_NAME}) = FlatArray
+ArrowTypes.fromarrow(::Type{<:FlatArray}, vec, size) = FlatArray{eltype(vec)}(vec, size)
 
 #####
 ##### `Weights`


### PR DESCRIPTION
Tests currently fail with the latest compatible versions of this package's dependencies because deserializing a `FlatArray` from Arrow ends up calling a `FlatArray` constructor method that doesn't exist: `FlatArray(vec, size)`. What it should actually call is the inner constructor, `FlatArray{T}(vec, size)`. To fix this, we can define a method for `fromarrow` from ArrowTypes to simply call the inner constructor. An analogous change is not needed for `Weights` because the method that `fromarrow` calls by default does exist in that case.

Note that no new tests were added. This is because the current tests actually cover this case.

Originally encountered by then pair debugged with @patinoam.